### PR TITLE
Class skeletons for geocache, image, and logbook

### DIFF
--- a/src/blueharvest/geocaching/data/geocache.java
+++ b/src/blueharvest/geocaching/data/geocache.java
@@ -8,12 +8,28 @@ package blueharvest.geocaching.data;
 /**
  *
  * @author jmb
+ * @since 2015-10-24
  */
 public abstract class geocache {
-    
-    //get
-    //insert
-    //update
-    //delete
-    
+
+    public static blueharvest.geocaching.objects.geocache get(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static boolean insert(blueharvest.geocaching.objects.geocache g) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean update(blueharvest.geocaching.objects.geocache g) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean delete(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not implemented.");
+    }
+
 }

--- a/src/blueharvest/geocaching/data/image.java
+++ b/src/blueharvest/geocaching/data/image.java
@@ -8,12 +8,28 @@ package blueharvest.geocaching.data;
 /**
  *
  * @author jmb
+ * @since 2015-10-24
  */
 public class image {
-    
-    //get
-    //insert
-    //update
-    //delete
-    
+
+    public static blueharvest.geocaching.objects.image get(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static boolean insert(blueharvest.geocaching.objects.image i) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean update(blueharvest.geocaching.objects.image i) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean delete(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not implemented.");
+    }
+
 }

--- a/src/blueharvest/geocaching/data/logbook.java
+++ b/src/blueharvest/geocaching/data/logbook.java
@@ -9,7 +9,27 @@ package blueharvest.geocaching.data;
  *
  * @author jmb
  * @since 2015-10-15 Back to the Future Day!
- */ 
+ */
 public class logbook {
-    
+
+    public static blueharvest.geocaching.objects.logbook get(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static boolean insert(blueharvest.geocaching.objects.logbook l) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean update(blueharvest.geocaching.objects.logbook l) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static final boolean delete(java.util.UUID id) {
+        // todo
+        throw new java.lang.UnsupportedOperationException("Not implemented.");
+    }
+
 }


### PR DESCRIPTION
Classes cannot use dynamic interfaces and static methods. The methods for each class in blueharvest.geocaching.data should all contain the methods implemented in the data.java interface. Because of this limitation, the classes have all methods from the data.java interface as a template to use for coding.
